### PR TITLE
tools: created credentials.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.db
 env/
+venv/
 __pycache__/
 *.pyc
 *.pyo

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from flask import render_template, request, send_from_directory, abort, redirect
 from app import app, db
 
 from models import *
+app.app_context().push()
 db.create_all()
 
 from util import catch_error, expect, commit_db, input_error, access_error, error
@@ -17,8 +18,7 @@ def room_days_query():
 
 # Match password against configured passwords
 def check_level(password):
-    # Yes, it's vulnerable to timing attacks. Ping the maintainer if this
-    # really matters.
+    # Yes, it's vulnerable to timing attacks. Ping the maintainer if this really matters.
     if password == app.config['EDITOR_KEY']:
         return 1
     if password == app.config['REVIEWER_KEY']:

--- a/signxml.py
+++ b/signxml.py
@@ -2,7 +2,7 @@ from app import db
 from models import RoomDay, Talk
 
 from xml.etree.ElementTree import fromstring
-from flask import Markup
+from markupsafe import Markup
 
 import iso8601
 

--- a/tools/credentials.py
+++ b/tools/credentials.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os, argparse, json
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.oauth2.credentials import Credentials
@@ -12,7 +14,9 @@ def parse_args():
 
 def main():
     args = parse_args()
+    google_api(args)
 
+def google_api(args):
     if os.path.isfile(args.token):
         print(f"Found {args.token}, reusing credentials")
         credentials = obtain_credentials_from_token(args.token)
@@ -26,6 +30,7 @@ def main():
                 "client_secret": credentials.client_secret,
                 "refresh_token": credentials.refresh_token,
             }, f)
+    return credentials
 
 def obtain_credentials_from_flow(client_file):
     flow = InstalledAppFlow.from_client_secrets_file(

--- a/tools/credentials.py
+++ b/tools/credentials.py
@@ -1,0 +1,43 @@
+import os, argparse, json
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.oauth2.credentials import Credentials
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Obtains credentials for youtube separate from upload.py")
+
+    parser.add_argument("-c", "--client", default="client_secrets.json", help="Path to client secrets file. Required if token is not valid (default: %(default)s)")
+    parser.add_argument("-t", "--token", default="credentials.json", help="Path to authorization token file. If does not exist or invalid, this script will take you through the Google OAuth process (default: %(default)s)")
+    parser.add_argument("--no-save-token", dest="save_token", action="store_false", help="Disable saving the authorization token to the path specified in (--token), after authorization.")
+    return parser.parse_args()
+
+def main():
+    args = parse_args()
+
+    if os.path.isfile(args.token):
+        print(f"Found {args.token}, reusing credentials")
+        credentials = obtain_credentials_from_token(args.token)
+    else:
+        print(f"Cannot find token file at {args.token}, starting authentication process")
+        credentials = obtain_credentials_from_flow(args.client)
+    if args.save_token:
+        with open(args.token, "w") as f:
+            json.dump({
+                "client_id": credentials.client_id,
+                "client_secret": credentials.client_secret,
+                "refresh_token": credentials.refresh_token,
+            }, f)
+
+def obtain_credentials_from_flow(client_file):
+    flow = InstalledAppFlow.from_client_secrets_file(
+        client_file,
+        scopes=['https://www.googleapis.com/auth/youtube.upload'])
+    flow.run_local_server(bind_addr="0.0.0.0", open_browser=False, port=10000)
+    return flow.credentials
+
+def obtain_credentials_from_token(token_file):
+    return Credentials.from_authorized_user_file(
+        token_file,
+        scopes=['https://www.googleapis.com/auth/youtube.upload'])
+
+if __name__ == "__main__":
+    main()

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -2,3 +2,4 @@ yt-dlp
 google-api-python-client
 google-auth-oauthlib
 google-auth-httplib2
+unidecode

--- a/tools/split.py
+++ b/tools/split.py
@@ -7,10 +7,12 @@ import json
 import subprocess
 import argparse
 import shutil
+from unidecode import unidecode
 
 vformat = "mp4"
 
 def rdash(s):
+    s = unidecode(s)
     return re.sub('[^0-9a-zA-Z]+', '-', s)
 
 def download_video(vid, outfile, container_format):

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -6,7 +6,7 @@ import argparse
 import re
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
-from credentials import obtain_credentials_from_flow, obtain_credentials_from_token
+from credentials import google_api
 from unidecode import unidecode
 
 vformat = "mp4"
@@ -111,19 +111,7 @@ def main():
     if not talks:
         return
     # Google API
-    if os.path.isfile(args.token):
-        print(f"Found {args.token}, reusing credentials")
-        credentials = obtain_credentials_from_token(args.token)
-    else:
-        print(f"Cannot find token file at {args.token}, starting authentication process")
-        credentials = obtain_credentials_from_flow(args.client)
-    if args.save_token:
-        with open(args.token, "w") as f:
-            json.dump({
-                "client_id": credentials.client_id,
-                "client_secret": credentials.client_secret,
-                "refresh_token": credentials.refresh_token,
-            }, f)
+    credentials = google_api(args)
 
     # Upload!
     yt = build('youtube', 'v3', credentials=credentials)

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -4,10 +4,9 @@ import os
 import json
 import argparse
 import re
-from google_auth_oauthlib.flow import InstalledAppFlow
-from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
+from credentials import obtain_credentials_from_flow, obtain_credentials_from_token
 
 vformat = "mp4"
 
@@ -27,18 +26,6 @@ def validate_youtube_description(desc):
         raise Exception(f"Description '{desc}' is longer than 5000 bytes. Modify JSON to include a valid youtube_description field.")
     if "<" in desc or ">" in desc:
         raise Exception(f"Description '{desc}' contains an invalid character. Modify JSON to include a valid youtube_description field.")
-
-def obtain_credentials_from_flow(client_file):
-    flow = InstalledAppFlow.from_client_secrets_file(
-        client_file,
-        scopes=['https://www.googleapis.com/auth/youtube.upload'])
-    flow.run_console()
-    return flow.credentials
-
-def obtain_credentials_from_token(token_file):
-    return Credentials.from_authorized_user_file(
-        token_file,
-        scopes=['https://www.googleapis.com/auth/youtube.upload'])
 
 def make_video_description(talk, desc):
     link = "https://www.socallinuxexpo.org" + talk["path"]
@@ -121,7 +108,6 @@ def main():
     print(f"Total: {len(talks)} talks to upload")
     if not talks:
         return
-
     # Google API
     if os.path.isfile(args.token):
         print(f"Found {args.token}, reusing credentials")

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -7,10 +7,12 @@ import re
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
 from credentials import obtain_credentials_from_flow, obtain_credentials_from_token
+from unidecode import unidecode
 
 vformat = "mp4"
 
 def rdash(s):
+    s = unidecode(s)
     return re.sub('[^0-9a-zA-Z]+', '-', s)
 
 def validate_youtube_title(title):


### PR DESCRIPTION
Addresses the authentication enhancement mentioned [here](https://github.com/socallinuxexpo/scale-av-cutter/issues/24).
Created a new credentials.py file to allow for separate initial authentication for Youtube uploads. To run credentials.py, execute `./credentials.py -c client_secrets.json`, where client_secrets.json is the file from the Google API Client.

Made some other changes so the flask app and scripts could run.
1. Added `app.app_context().push()` in main.py and changed `flow.run_console()` to `flow.run_local_server(bind_addr="0.0.0.0", open_browser=False, port=10000)`.
2. In signxml.py, instead of importing Markup from flask, changed to importing Markup from markupsafe.

Commit 2:
Fixed issue #8, requires `pip install unidecode`