### PR TITLE
static/templates: added check in/out to index page

### DIFF
--- a/main.py
+++ b/main.py
@@ -179,6 +179,26 @@ def comment():
     room_day.comment = comment
     return {}
 
+@app.route('/checked_out', methods=['POST'])
+@catch_error
+@commit_db
+def checked_out():
+    # Check for access level
+    _, level = access(require_name=False)
+    if level < 1:
+        access_error()
+
+    room_day_id = expect(request, 'id')
+    checked_out_by = expect(request, 'checked_out_by')
+
+    # Get room day
+    room_day = db.session.query(RoomDay).get(room_day_id)
+    if not room_day:
+        input_error()
+
+    room_day.checked_out_by = checked_out_by
+    return {}
+
 @app.route('/xml', methods=['POST'])
 @catch_error
 @commit_db

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,11 +68,20 @@
         <span> - </span>
         <span class="roomday-comment-text">{{ room_day.comment|e }}</span>
       </span>
+      <br>
+      <button title="Click this if you are currently editing this room" type="button" class="roomday-checkin">CHECK IN</button>
+      <button title="Click this if you are no longer editing this room" type="button" class="roomday-checkout">CHECK OUT</button>
+      
+      <em>Currently edited by: <span class="currently-editing">{{ room_day.checked_out_by }}</span></em>
+      <br><br>
     </div>
     {% endfor %}
   </div>
   {% endif %}
 
+  <script>
+    var displayName = {{ name|tojson }};
+  </script>
   <script src="/static/index.js?v=1"></script>
 </body>
 </html>


### PR DESCRIPTION
Addresses issues #38 and #14 regarding keeping track of who is currently editing which room. Added a check-in and check-out button for each room on the index page. Editors can check-in when they start editing a page, and their name is displayed on the side. When they finish editing, they can click the check-out button so their name stops displaying. This helps us coordinate who is working on each room, so our work isn't wasted or overwritten.

![image](https://github.com/socallinuxexpo/scale-av-cutter/assets/111592935/8a0fd3a0-f4d4-4002-9624-6420d1442724)

Also, if a user tries to check-in when someone has already checked-in for that room, an alert will pop up, stopping them. A similar alert will pop up if a user tries to check-out for someone else.
