### PR TITLE
static: automatic time skip for YT player

### DIFF
--- a/static/roomday.js
+++ b/static/roomday.js
@@ -102,6 +102,17 @@ document.addEventListener("DOMContentLoaded", function()
   }
 });
 
+// Automatic time skip for Youtube player
+var player = document.querySelector("#player");
+player.focus();
+document.addEventListener('keydown', function(e) {
+  if (e.key == "ArrowLeft") {
+    player.seekTo(player.getCurrentTime() - 10, true);
+  } else if (e.key == "ArrowRight") {
+    player.seekTo(player.getCurrentTime() + 10, true);
+  }
+});
+
 function getVid() {
   return document.querySelector("#player").dataset.vid;
 }


### PR DESCRIPTION
#41 
Unfortunately, we can't use a keyboard shortcut to automatically focus the Youtube player video, due to it [violating the same-origin policy](https://stackoverflow.com/a/33948692). However, we can use shortcuts to automatically skip 10 seconds before or after the current time. 

The left arrow button automatically skips 10 seconds before and the right arrow button automatically skips 10 seconds after. However, if you're clicked in a text box for time input or a radio button for edit/review status, the arrow buttons still do their regular functionality on top of skipping 10 seconds. So you do have to click out of a text box or radio button onto white space for it to only do the video skipping.

@ldang let me know if the current key binds (left/right arrow keys) work or if you want them changed to something else.