### PR TITLE
Updated download format code in split.py

### DIFF
--- a/tools/split.py
+++ b/tools/split.py
@@ -21,10 +21,12 @@ def download_video(vid, outfile, container_format):
     """
     url = f"https://youtube.com/watch?v={vid}"
 
-    download_format = "bestvideo+bestaudio/best"
-    if container_format == "mp4":
-        download_format = "mp4"
-
+    # Directly from yt-dlp manual
+    # Download the best mp4 video available, or the best video if no mp4 available
+    #  $ yt-dlp -f "bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4] / bv*+ba/b"
+ 
+    download_format = f"bv*[ext={container_format}]+ba[ext=m4a]/b[ext={container_format}] / bv*+ba/b"
+    
     ret = subprocess.call([
         "yt-dlp",
         "-o", outfile,          # Output filename


### PR DESCRIPTION
To address issue #55, discovered that  when we download the room-long stream, it comes down in 720p, despite us requesting best video/best audio.   The culprit was a conditional where the container_format automatically set the download_format to "mp4"

Removing the conditional was the main fix, but took the opportunity to update the download format using the example from yt-dlp manual, to ensure that we are downloading in mp4.