### PR TITLE
58 uploadpy error on thumbnail upload due to 2 mb limit

### DIFF
--- a/tools/split.py
+++ b/tools/split.py
@@ -54,7 +54,8 @@ def make_thumbnail(video, time, outfile):
         "-y",               # Yes, overwrite
         "-ss", str(time),   # Time of thumbnail capture
         "-i", video,        # Input
-        "-frames", "1",     # Number of frames
+        "-frames:v", "1",   # Number of frames
+        "-qscale:v", "2",   # Quality of JPEG
         outfile,            # Output
     ])
 
@@ -127,7 +128,7 @@ def main():
                 print(f"WARNING: talk {title} has zero length video. Skipping." )
 
             talk_name = f"{title}.{vformat}"
-            image_name = f"{title}.png"
+            image_name = f"{title}.jpeg"
             talk_path = os.path.join(subdir_path, talk_name)
             thumbnail_path = os.path.join(subdir_path, image_name)
 

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -51,7 +51,7 @@ def collect_talks(room_days, workdir):
         for talk in room_day["talks"]:
             talk_title = rdash(talk["title"])
             talk_name = f"{talk_title}.{vformat}"
-            thumbnail_name = f"{talk_title}.png"
+            thumbnail_name = f"{talk_title}.jpeg"
             talk_path = os.path.join(subdir_path, talk_name)
             thumbnail_path = os.path.join(subdir_path, thumbnail_name)
             if not os.path.isfile(talk_path):


### PR DESCRIPTION
#58 Changed thumbnail type from PNG to JPEG and added ffmpeg argument to control the quality of the JPEG image. Tested it a few times and the thumbnail images range from 50 KB to 100 KB, so it should no longer exceed the 2 MB limit.