### PR TITLE
tools: added additional details on video upload

### DIFF
--- a/main.py
+++ b/main.py
@@ -228,6 +228,7 @@ def generate_json():
         room_day_info = {
             "room": room_day.room,
             "day": room_day.day,
+            "date": room_day.date,
             "vid": room_day.vid,
             "talks": [
                 {
@@ -270,6 +271,7 @@ def generate_json_individual(day, room):
         room_day_info = {
             "room": room_day.room,
             "day": room_day.day,
+            "date": room_day.date,
             "vid": room_day.vid,
             "talks": [
                 {

--- a/main.py
+++ b/main.py
@@ -228,7 +228,7 @@ def generate_json():
         room_day_info = {
             "room": room_day.room,
             "day": room_day.day,
-            "date": room_day.date,
+            "date": room_day.date.isoformat(),
             "vid": room_day.vid,
             "talks": [
                 {
@@ -271,7 +271,7 @@ def generate_json_individual(day, room):
         room_day_info = {
             "room": room_day.room,
             "day": room_day.day,
-            "date": room_day.date,
+            "date": room_day.date.isoformat(),
             "vid": room_day.vid,
             "talks": [
                 {

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -8,6 +8,7 @@ from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
 from credentials import google_api
 from unidecode import unidecode
+from datetime import datetime
 
 vformat = "mp4"
 
@@ -44,8 +45,10 @@ def collect_talks(room_days, workdir):
     for room_day in room_days["room_days"]:
         room = room_day["room"]
         day = room_day["day"]
+        date = room_day["date"]
 
         room_day_name = f"{rdash(room)}-{rdash(day)}"
+        room_date = datetime.strptime(date, '%a, %d %b %Y %H:%M:%S %Z').isoformat()
         subdir_path = os.path.join(workdir, room_day_name)
 
         for talk in room_day["talks"]:
@@ -66,6 +69,7 @@ def collect_talks(room_days, workdir):
                 "description": youtube_desc,
                 "file": talk_path,
                 "thumbnail": thumbnail_path,
+                "date": room_date,
             })
 
     return talks
@@ -122,17 +126,24 @@ def main():
         size = os.path.getsize(talk["file"])
         print(f"Uploading \"{talk['title']}\" ({size} bytes)...")
         video = MediaFileUpload(talk['file'], chunksize=1024*1024, resumable=True)
+        date = talk['date']
         request = yt.videos().insert(
-            part="id,snippet,status",
+            part="id,snippet,status,recordingDetails",
             body={
                 "snippet": {
                     "title": talk["title"],
                     "description": talk["description"],
+                    "defaultLanguage": "en",
+                    "defaultAudioLanguage": "en",
                 },
                 "status": {
                     "privacyStatus": args.privacy,
                     "selfDeclaredMadeForKids": False,
+                    "license": "creativeCommon",
                 },
+                "recordingDetails": {
+                    "recordingDate": date,
+                }
             },
             media_body=video)
         response = None

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -8,7 +8,6 @@ from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
 from credentials import google_api
 from unidecode import unidecode
-from datetime import datetime
 
 vformat = "mp4"
 
@@ -48,7 +47,6 @@ def collect_talks(room_days, workdir):
         date = room_day["date"]
 
         room_day_name = f"{rdash(room)}-{rdash(day)}"
-        room_date = datetime.strptime(date, '%a, %d %b %Y %H:%M:%S %Z').isoformat()
         subdir_path = os.path.join(workdir, room_day_name)
 
         for talk in room_day["talks"]:
@@ -69,7 +67,7 @@ def collect_talks(room_days, workdir):
                 "description": youtube_desc,
                 "file": talk_path,
                 "thumbnail": thumbnail_path,
-                "date": room_date,
+                "date": date,
             })
 
     return talks
@@ -142,7 +140,7 @@ def main():
                     "license": "creativeCommon",
                 },
                 "recordingDetails": {
-                    "recordingDate": date,
+                    "recordingDate": date + "T00:00:00Z",
                 }
             },
             media_body=video)


### PR DESCRIPTION
#70: Added default language, audio language, license, and recording date details to Youtube API JSON request when uploading videos. Was not able to add the recording location since it was [depreciated](https://developers.google.com/youtube/v3/revision_history#release_notes_06_01_2017) a while ago. In order to get recording date of the talk, I added date to the application's JSON from the database.